### PR TITLE
Compute accent color

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -22,8 +22,9 @@
 /* Base */
 
 :root {
-  --theme-text-color: #ee4792;
-  --theme-highlight-color: #fcdae9;
+	--accent-color: 238, 71, 146;
+	--accent-text-color: rgba(var(--accent-color), 1);
+	--accent-highlight-color: rgba(var(--accent-color), 0.2);
 }
 
 html, body {
@@ -102,16 +103,16 @@ nav.main-nav a {
 }
 nav.main-nav a.cta {
 	background: #fff;
-	color: var(--theme-text-color);
+	color: var(--accent-text-color);
 	padding: 6px 16px;
-	border: 2px solid var(--theme-highlight-color);
+	border: 2px solid var(--accent-highlight-color);
 	border-bottom: none;
 	border-radius: 20px;
 }
 
 nav.main-nav a.cta:hover {
-	background: var(--theme-highlight-color);
-	color: var(--theme-text-color);
+	background: var(--accent-highlight-color);
+	color: var(--accent-text-color);
 	margin-left: 12px;
 }
 
@@ -162,13 +163,13 @@ a {
 	text-decoration: none;
 	color: #000;
 	font-weight: 500;
-	box-shadow: inset 0 -2px 0 var(--theme-highlight-color);
+	box-shadow: inset 0 -2px 0 var(--accent-highlight-color);
 	transition: all .35s;
   transition-timing-function: cubic-bezier(.7, 0, .3, 1);
 }
 
 a:hover {
-	box-shadow: inset 0 -25px 0 var(--theme-highlight-color);
+	box-shadow: inset 0 -25px 0 var(--accent-highlight-color);
 }
 
 /* Post */


### PR DESCRIPTION
RE: https://github.com/mmarfil/marfa/pull/2#issuecomment-388597202

The ideas was to consolidate our two variables down to one.

The implementation I was looking into was computing the second color as 20% opacity of the first with the `rgba` function.

I have two issues with the change as is:

* `--accent-color` needs to be defined as an unwrapped RGB list. You can't use hex for an example.
* I'm seeing some weird blending issue when switching to RGB colors on the cta hover transition. It doesn't seem to be related to variables, just `rgba`. I'm not sure what's going on here.

<img width="168" alt="screen shot 2018-05-12 at 10 15 47 pm" src="https://user-images.githubusercontent.com/137/39964142-649140b6-5632-11e8-855d-c947d6a71f77.png">

@mmarfil any other ideas how this could be accomplished?